### PR TITLE
Add SQLite export subsystem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 /doc/_build
 .coverage*
 coverage.xml
+*.sqlite

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ development
 ===========
 - Naming things: Rename ``DwdPhenoData`` to ``DwdPhenoDataClient``
 - Documentation: Add logo image. Thanks, @ClemensGruber.
+- Add SQLite export subsystem
 
 2023-04-11 0.13.1
 =================

--- a/README.rst
+++ b/README.rst
@@ -504,6 +504,30 @@ statement to filter the results by station name, and sort them by date::
         --sql="SELECT * FROM data WHERE Station LIKE '%Berlin%' ORDER BY Datum" \
         --format=md
 
+Data export
+===========
+
+You can use the ``phenodata export-observation`` subcommand to export observations
+including metadata into an `SQLite`_ database.
+
+.. code-block:: bash
+
+    phenodata export-observations \
+        --source=dwd --dataset=annual --partition=recent \
+        --station=münchen \
+        --year=2021,2022,2023 \
+        --filename=Hasel \
+        --target=sqlite:///phenodata-dwd-sample.sqlite
+
+To get an idea about the data, run your first query.
+
+.. code-block:: bash
+
+    sqlite3 -csv -header phenodata-dwd-sample.sqlite 'SELECT * FROM dwd_phenology ORDER BY date;'
+
+Please refer to the :ref:`sqlite-export` documentation about more details how
+to use that feature, and about what you can do with it.
+
 
 *******************
 Project information
@@ -581,6 +605,7 @@ easily.
 .. _presets.json: https://github.com/earthobservations/phenodata/blob/main/phenodata/dwd/presets.json
 .. _reStructuredText: https://en.wikipedia.org/wiki/ReStructuredText
 .. _share it back with us: https://github.com/earthobservations/phenodata/discussions/new?category=show-and-tell
+.. _SQLite: https://sqlite.org/
 .. _tabulate: https://github.com/astanin/python-tabulate
 .. _virtualenv: https://github.com/earthobservations/phenodata/blob/main/doc/virtualenv.rst
 .. _Xarray: https://xarray.dev/

--- a/doc/archive/dwd.rst
+++ b/doc/archive/dwd.rst
@@ -1,0 +1,107 @@
+.. _dwd-archive:
+
+###########################
+DWD SQLite database archive
+###########################
+
+
+*****
+About
+*****
+
+This section explains how to export all available datasets into corresponding `SQLite`_
+database files, using the ``phenodata export-observations-all`` subcommand.
+
+If you want to create database files by selecting individual subsets of the data,
+please refer to the :ref:`sqlite-export` documentation.
+
+
+*******
+Archive
+*******
+
+The SQLite database files produced by phenodata can be downloaded at
+https://phenodata.hiveeyes.org/. Please recognize the DWD data copyright
+notices referenced below.
+
+
+*****
+Usage
+*****
+
+.. code-block:: python
+
+    phenodata export-observations-all
+
+The command will create four SQLite database files, they can be :ref:`consumed
+<sqlite-usage-consume>` using the ``sqlite3`` command, or other tools.
+
+- ``phenodata-dwd-annual-historical.sqlite`` (1.7 GB)
+- ``phenodata-dwd-annual-recent.sqlite`` (24 MB)
+- ``phenodata-dwd-immediate-historical.sqlite`` (90 MB)
+- ``phenodata-dwd-immediate-recent.sqlite`` (5.5 MB)
+
+.. note::
+
+    The cache directory, for example located at ``/Users/<username>/Library/Caches/phenodata``
+    on macOS machines, will hold all the data downloaded from DWD servers. It is about
+    160 MB in size for both of the "recent" datasets, while ``immediate-historical``
+    weighs in with about 500 MB, and ``annual-historical`` with about 3 GB.
+
+
+************
+Attributions
+************
+
+Data copyright
+==============
+
+    All information on the web pages of the DWD is protected by copyright.
+    As laid down in the Ordinance Setting the Terms of Use for the Provision of
+    Federal Spatial Data (GeoNutzV), all spatial data and spatial data services
+    available "for free" access may be used without any restrictions provided that
+    the source is acknowledged. When speaking of spatial data, this also includes
+    any location-related weather and climate information presented on the DWD open
+    web pages.
+
+    Any other content presented on DWD web pages, in whole or extracts thereof, may
+    be reproduced, altered, distributed, used or publicly presented only if expressly
+    permitted by the DWD.
+
+.. image:: https://www.dwd.de/SharedDocs/bilder/DE/logos/dwd/dwd_logo_258x69.png?__blob=normal&v=1
+
+| Source: Deutscher Wetterdienst (DWD)
+| Copyright information: `en <copyright-en_>`_, `de <copyright-de_>`_
+| GeoNutzV: `en <GeoNutzV (en)_>`_, `de <GeoNutzV (de)_>`_
+
+Acknowledgements
+================
+
+Thanks to the many observers of »Deutscher Wetterdienst« (DWD), the »Global
+Phenological Monitoring programme« (GPM), and all people working behind the
+scenes for their commitment on recording observations and making the excellent
+datasets available to the community. You know who you are.
+
+
+*******
+Backlog
+*******
+
+.. todo::
+
+    - [o] Publish using `datasette`_
+    - [o] Publish using `Grafana SQLite Datasource`_
+    - [o] Outline other end-user tools to consume the databases
+    - [o] Implement ``phenodata.open_database("dwd", "immediate", "recent")``
+      to consume the databases
+    - [o] Acknowledge PPODB
+    - [o] Add a few SQL query examples
+
+
+.. _copyright-de: https://www.dwd.de/DE/service/copyright/copyright_node.html
+.. _copyright-en: https://www.dwd.de/EN/service/copyright/copyright_node.html
+.. _datasette: https://datasette.io/
+.. _GeoNutzV (de): https://www.gesetze-im-internet.de/geonutzv/GeoNutzV.pdf
+.. _GeoNutzV (en): https://www.bmuv.de/fileadmin/Daten_BMU/Download_PDF/Strategien_Bilanzen_Gesetze/130309_geonutzv_bgbi_englisch_bf.pdf
+.. _Grafana SQLite Datasource: https://grafana.com/grafana/plugins/frser-sqlite-datasource/
+.. _SQLite: https://sqlite.org/

--- a/doc/export/sqlite.rst
+++ b/doc/export/sqlite.rst
@@ -1,0 +1,141 @@
+.. _sqlite-export:
+
+######################
+SQLite database export
+######################
+
+
+*****
+About
+*****
+
+You can use the ``phenodata export-observations`` subcommand to export observations
+including metadata into an `SQLite`_ database.
+
+The database will contain the data table ``dwd_observation``, and the metadata
+tables ``dwd_station``, ``dwd_species``, ``dwd_phase``, ``dwd_quality_byte``,
+and ``dwd_quality_level``. There is also a `database view`_ called ``dwd_phenology``,
+which will join those tables together properly, and present a `denormalized`_ variant
+of the data, ready for convenient querying.
+
+If you want to create SQLite database archive files, containing **all datasets**,
+please follow up reading the :ref:`dwd-archive` documentation section.
+
+
+.. _sqlite-usage:
+
+*****
+Usage
+*****
+
+.. _sqlite-usage-produce:
+
+Produce
+=======
+
+This example walks you through the steps needed to store a subset of the phenology
+observation data available on DWD CDC into an SQLite database file on your machine.
+
+Let's start by defining the database name.
+
+.. code-block:: bash
+
+    export DBPATH=phenodata-dwd-annual-recent-hasel.sqlite
+
+Now, export a few selected data points to keep the database size small.
+
+.. code-block:: bash
+
+    phenodata export-observations \
+        --source=dwd --dataset=annual --partition=recent \
+        --station=münchen \
+        --year=2021,2022,2023 \
+        --filename=Hasel \
+        --target=sqlite:///${DBPATH}
+
+.. attention::
+
+    Please note that each invocation will **overwrite (replace)** all tables
+    within the given database without confirmation.
+
+
+.. _sqlite-usage-consume:
+
+Consume
+=======
+
+Inquire the database schema.
+
+.. code-block:: bash
+
+    sqlite3 "${DBPATH}" '.tables'
+    sqlite3 "${DBPATH}" '.fullschema --indent'
+
+Run a query on the ``dwd_phenology`` view.
+
+.. code-block:: bash
+
+    sqlite3 -csv -header "${DBPATH}" 'SELECT * FROM dwd_phenology ORDER BY date;'
+
+.. code-block:: bash
+
+    sqlite3 -csv -header "${DBPATH}" <<SQL
+    SELECT * FROM dwd_phenology ORDER BY date;
+    SQL
+
+
+*******
+Details
+*******
+
+You can always inspect the database schema using ``sqlite3 "${DBPATH}" '.fullschema
+--indent'``. In order to learn about how the ``dwd_phenology`` `database view`_
+looks like, this SQL example can be helpful.
+
+.. code-block:: sql
+
+    sqlite3 -csv -header "${DBPATH}" <<SQL
+    SELECT
+       dwd_observation.*,
+       dwd_station.*,
+       dwd_station.station_name AS station_name,
+       dwd_species.species_name_en AS species_name,
+       dwd_phase.phase_name_en AS phase_name
+    FROM
+       dwd_observation, dwd_station, dwd_species, dwd_phase
+    WHERE true
+       AND dwd_observation.station_id=dwd_station.id
+       AND dwd_observation.species_id=dwd_species.id
+       AND dwd_observation.phase_id=dwd_phase.id
+    SQL
+
+.. note::
+
+    Please note this SQL example omits joining in the ``dwd_quality_byte``
+    and ``dwd_quality_level`` tables for better readability. The view
+    ``dwd_phenology`` *does* include them.
+
+
+*******
+Backlog
+*******
+
+.. todo::
+
+    - [o] Add ``copyright`` table, including corresponding information from DWD
+    - [o] Insert and query ``presets`` table
+    - [o] How to publish using `datasette`_
+    - [o] How to publish using `Grafana SQLite Datasource`_
+    - [o] Explore compression options
+
+      - https://stackoverflow.com/questions/10824347/does-sqlite3-compress-data
+      - https://phiresky.github.io/blog/2022/sqlite-zstd/
+      - https://hackaday.com/2022/08/01/never-too-rich-or-thin-compress-sqlite-80/
+      - https://github.com/phiresky/sqlite-zstd
+
+
+.. _database view: https://en.wikipedia.org/wiki/View_(SQL)
+.. _datasette: https://datasette.io/
+.. _denormalized: https://en.wikipedia.org/wiki/Denormalization
+.. _Grafana SQLite Datasource: https://grafana.com/grafana/plugins/frser-sqlite-datasource/
+.. _SQLite: https://sqlite.org/

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -15,6 +15,8 @@
 
     notebook/index
     forecasts
+    export/sqlite
+    archive/dwd
 
 
 .. toctree::

--- a/phenodata/dwd/cdc.py
+++ b/phenodata/dwd/cdc.py
@@ -23,7 +23,7 @@ class DwdCdcClient:
     # Instance of ``phenodata.ftp.FTPSession`` object for lowlevel access to CDC FTP
     ftp = attr.ib()
 
-    def get_dataframe(self, url=None, path=None, index_column=None, coerce_int=False):
+    def get_dataframe(self, url=None, path=None, index_column=None, coerce_int=False) -> pd.DataFrame:
         """
         Read single CSV file from FTP url and convert to pandas DataFrame object.
 
@@ -86,7 +86,7 @@ class DwdCdcClient:
 
         return StringIO(content)
 
-    def csv_to_dataframe(self, stream, index_column=None, coerce_int=False):
+    def csv_to_dataframe(self, stream, index_column=None, coerce_int=False) -> pd.DataFrame:
         """
         Read CSV data from stream into pandas DataFrame object.
 

--- a/phenodata/dwd/export.py
+++ b/phenodata/dwd/export.py
@@ -1,0 +1,39 @@
+import logging
+import typing as t
+
+from phenodata.dwd.model import DwdPhenoDataset, DwdPhenoDatabase, DwdPhenoPartition
+from phenodata.dwd.pheno import DwdPhenoDataClient
+
+
+logger = logging.getLogger(__name__)
+
+
+def acquire_database(client: DwdPhenoDataClient, options: t.Optional[t.Dict[str, str]] = None) -> DwdPhenoDatabase:
+    options = options or {}
+    dataset = options.get("dataset", "unknown")
+    partition = options.get("partition", "unknown")
+    db = DwdPhenoDatabase(
+        dataset=DwdPhenoDataset(dataset),
+        partition=DwdPhenoPartition(partition),
+        species=client.get_species(),
+        phase=client.get_phases(),
+        quality_level=client.get_quality_levels(),
+        quality_byte=client.get_quality_bytes(),
+        station=client.get_stations(filter=options['filter'], all=options['all']),
+        observation=client.get_observations(options=options),
+    )
+    db.observation["source"] = "dwd"
+    db.observation["dataset"] = db.dataset.name.lower()
+    db.observation["partition"] = db.partition.name.lower()
+    return db
+
+
+def export_database(client, target, options):
+    logger.info(f"Exporting data to {target}")
+    # TODO: Warn that specific options will not be honored.
+    db = acquire_database(client=client, options=options).with_canonical_column_names()
+    db.info()
+    db.to_sql(target)
+    # Optionally print samples.
+    # print(db.observations)
+    logger.info(f"Exported data to {target}")

--- a/phenodata/dwd/model.py
+++ b/phenodata/dwd/model.py
@@ -1,0 +1,199 @@
+import dataclasses
+import io
+import logging
+from contextlib import redirect_stdout
+from enum import Enum
+import typing as t
+
+import pandas as pd
+from sqlalchemy import create_engine, Engine
+import sqlalchemy as sa
+
+logger = logging.getLogger(__name__)
+
+
+class DwdPhenoDataset(Enum):
+    ANNUAL = "annual"
+    IMMEDIATE = "immediate"
+
+
+class DwdPhenoPartition(Enum):
+    RECENT = "recent"
+    HISTORICAL = "historical"
+
+
+@dataclasses.dataclass
+class CanonicalCollection:
+    index_names: t.List[str]
+    column_map: t.Dict[str, str]
+
+
+class CanonicalColumnMap:
+    species = CanonicalCollection(
+        index_names=["id"],
+        column_map={
+            "Objekt": "species_name_de",
+            "Objekt_englisch": "species_name_en",
+            "Objekt_latein": "species_name_la",
+        },
+    )
+    phase = CanonicalCollection(
+        index_names=["id"],
+        column_map={
+            "Phase": "phase_name_de",
+            "Phase_englisch": "phase_name_en",
+        },
+    )
+    station = CanonicalCollection(
+        index_names=["id"],
+        column_map={
+            "Stationsname": "station_name",
+            "geograph.Breite": "latitude",
+            "geograph.Laenge": "longitude",
+            "Stationshoehe": "altitude",
+            "Naturraumgruppe_Code": "area_group_code",
+            "Naturraumgruppe": "area_group",
+            "Naturraum_Code": "area_code",
+            "Naturraum": "area",
+            "Datum Stationsaufloesung": "station_date_abandoned",
+            "Bundesland": "state",
+        },
+    )
+    quality_level = CanonicalCollection(
+        index_names=["id"],
+        column_map={
+            "Beschreibung": "description",
+        },
+    )
+    quality_byte = CanonicalCollection(
+        index_names=["id"],
+        column_map={
+            "Beschreibung": "description",
+        },
+    )
+    observation = CanonicalCollection(
+        index_names=["id"],
+        column_map={
+            "Stations_id": "station_id",
+            "Referenzjahr": "reference_year",
+            "Qualitaetsniveau": "quality_level_id",
+            "Objekt_id": "species_id",
+            "Phase_id": "phase_id",
+            "Eintrittsdatum": "date",
+            "Eintrittsdatum_QB": "quality_byte_id",
+            "Jultag": "day_of_year",
+        },
+    )
+
+
+@dataclasses.dataclass
+class DwdPhenoDatabase:
+    dataset: DwdPhenoDataset
+    partition: DwdPhenoPartition
+    species: pd.DataFrame
+    phase: pd.DataFrame
+    quality_level: pd.DataFrame
+    quality_byte: pd.DataFrame
+    station: pd.DataFrame
+    observation: pd.DataFrame
+
+    @property
+    def slots(self):
+        return [self.species, self.phase, self.quality_level, self.quality_byte, self.station, self.observation]
+
+    def info(self):
+        for slot in self.slots:
+            print(f"### {slot.attrs['name']}")
+            slot.info()
+            print()
+
+    def __repr__(self):
+        buffer = io.StringIO()
+        with redirect_stdout(buffer) as out:
+            for slot in self.slots:
+                print(f"### {slot.attrs['name']}")
+                print(slot)
+                print()
+        buffer.seek(0)
+        return buffer.read()
+
+    def with_canonical_column_names(self) -> "DwdPhenoDatabase":
+        """
+        Translate DWD column names to canonical english column names.
+        """
+        for slot in self.slots:
+            thing = slot
+            name = thing.attrs["name"]
+            transformer = getattr(CanonicalColumnMap, name, None)
+            if transformer:
+                thing = thing.rename(columns=transformer.column_map)
+                thing.index.names = transformer.index_names
+                setattr(self, name, thing)
+        return self
+
+    def to_sql(self, dsn: str):
+        """
+        Export data to RDBMS/SQL database.
+        """
+        engine = create_engine(dsn)
+        with engine.connect() as connection:
+            connection.execute(sa.text("DROP VIEW IF EXISTS dwd_phenology;"))
+            connection.commit()
+
+        for slot in self.slots:
+            name = slot.attrs["name"]
+            table_name = f"dwd_{name}"
+            slot.to_sql(name=table_name, con=engine, if_exists="replace")
+
+        self.to_sql_create_view(engine)
+
+    def to_sql_create_view(self, engine: Engine):
+
+        """
+        createview = CreateView('viewname', t.select().where(t.c.id > 5))
+        engine.execute(createview)
+        return
+        """
+
+        with engine.connect() as connection:
+            connection.execute(sa.text("DROP VIEW IF EXISTS dwd_phenology;"))
+            connection.execute(sa.text("""
+CREATE VIEW dwd_phenology AS
+   SELECT
+      dwd_observation.source,
+      dwd_observation.dataset,
+      dwd_observation.partition,
+      dwd_station.station_name,
+      dwd_station.station_name || ', ' ||
+          dwd_station.area_group || ', ' ||
+          dwd_station.area || ', ' ||
+          dwd_station.state
+          AS station_full,
+      dwd_observation.date,
+      dwd_observation.day_of_year,
+      dwd_species.species_name_en,
+      dwd_species.species_name_de,
+      dwd_phase.phase_name_en,
+      dwd_phase.phase_name_de,
+      dwd_quality_level.description AS quality_level,
+      dwd_quality_byte.description AS quality_byte,
+      dwd_observation.reference_year,
+      dwd_station.latitude,
+      dwd_station.longitude,
+      dwd_station.altitude,
+      dwd_station.area_group_code,
+      dwd_station.area_group,
+      dwd_station.area_code,
+      dwd_station.area,
+      dwd_station.state,
+      dwd_station.station_date_abandoned
+   FROM
+      dwd_observation, dwd_station, dwd_species, dwd_phase, dwd_quality_level, dwd_quality_byte
+   WHERE true
+      AND dwd_observation.station_id=dwd_station.id
+      AND dwd_observation.species_id=dwd_species.id
+      AND dwd_observation.phase_id=dwd_phase.id
+      AND dwd_observation.quality_level_id=dwd_quality_level.id
+      AND dwd_observation.quality_byte_id=dwd_quality_byte.id
+            """))
+            connection.commit()

--- a/phenodata/dwd/pheno.py
+++ b/phenodata/dwd/pheno.py
@@ -52,26 +52,34 @@ class DwdPhenoDataClient:
         """
         Return DataFrame with species information
         """
-        return self.cdc.get_dataframe(path='/help/PH_Beschreibung_Pflanze.txt', index_column=0)
+        df: pd.DataFrame = self.cdc.get_dataframe(path='/help/PH_Beschreibung_Pflanze.txt', index_column=0)
+        df.attrs["name"] = "species"
+        return df
 
     def get_phases(self):
         """
         Return DataFrame with phases information
         """
-        return self.cdc.get_dataframe(path='/help/PH_Beschreibung_Phase.txt', index_column=0)
+        df = self.cdc.get_dataframe(path='/help/PH_Beschreibung_Phase.txt', index_column=0)
+        df.attrs["name"] = "phase"
+        return df
 
     def get_quality_levels(self):
         """
         Return DataFrame with quality level information
         """
-        return self.cdc.get_dataframe(path='/help/PH_Beschreibung_Phaenologie_Qualitaetsniveau.txt', index_column=0)
+        df = self.cdc.get_dataframe(path='/help/PH_Beschreibung_Phaenologie_Qualitaetsniveau.txt', index_column=0)
+        df.attrs["name"] = "quality_level"
+        return df
 
     def get_quality_bytes(self):
         """
         Return DataFrame with quality bytes information
         ftp://opendata.dwd.de/climate_environment/CDC/observations_germany/climate/subdaily/standard_format/qualitaetsbytes.pdf
         """
-        return self.cdc.get_dataframe(path='/help/PH_Beschreibung_Phaenologie_Qualitaetsbyte.txt', index_column=0)
+        df = self.cdc.get_dataframe(path='/help/PH_Beschreibung_Phaenologie_Qualitaetsbyte.txt', index_column=0)
+        df.attrs["name"] = "quality_byte"
+        return df
 
     def get_stations(self, filter=None, all=False):
         """
@@ -115,6 +123,8 @@ class DwdPhenoDataClient:
             # Apply filter expression to DataFrame
             if type(expression) is not bool:
                 data = data[expression]
+
+        data.attrs["name"] = "station"
 
         return data
 
@@ -183,9 +193,7 @@ class DwdPhenoDataClient:
             megaframe = self.create_megaframe(observations)
             observations = self.humanizer.get_observations(megaframe)
 
-        # or pass-through with minor cosmetic amendments
-        else:
-            observations['Eintrittsdatum'] = observations['Eintrittsdatum'].astype(str)
+        observations.attrs["name"] = "observation"
 
         return observations
 
@@ -248,6 +256,8 @@ class DwdPhenoDataClient:
         # or pass-through with minor cosmetic amendments
         else:
             forecast['Datum'] = forecast['Datum'].astype(str)
+
+        forecast.attrs["name"] = "forecast"
 
         return forecast
 

--- a/setup.py
+++ b/setup.py
@@ -7,12 +7,14 @@ README = open(os.path.join(here, 'README.rst')).read()
 requires = [
     'arrow>=0.12.1,<1.3',
     'attrs>=17.4.0',
+    'charset-normalizer<3',
     'docopt>=0.6.2',
     'dogpile.cache>=0.6.5,<2',
     'pandas>=1.3,<2.1',
     'platformdirs<4',
     'requests>=2.18.4,<3',
     'requests-ftp>=0.3.1,<4',
+    'sqlalchemy>2,<2.1',
     'tabulate>=0.8.2,<0.10',
     'tqdm>=4.60,<5',
 ]


### PR DESCRIPTION
In order to use the [Grafana SQLite Datasource](https://grafana.com/grafana/plugins/frser-sqlite-datasource/) for displaying phenology data within Grafana without further ado, we are adding a subsystem to export the acquired data into an SQLite database.

/cc @ClemensGruber, @msweef