### PR TITLE
SQLite export: Add `dwd_species_group` table from `presets.json` file

### DIFF
--- a/doc/archive/dwd.rst
+++ b/doc/archive/dwd.rst
@@ -197,12 +197,65 @@ all lengths and phases (see Figure 1 in the documentation)?::
         )
     AS sq GROUP BY c;
 
-Herder's toolbox
-================
+Specialist's toolbox
+====================
 
-.. todo::
+A few queries suitable for beekeepers and friends. The group ``mellifera-de-primary``
+is defined in phenodata's `presets.json`_ file, amongst others. Its content is available
+through the database table ``dwd_species_group``. This statement lists all observations
+of "flowering" events for primary foraging plants of honeybees (apis mellifera)::
 
-    A few queries suitable for beekeepers and friends.
+    SELECT
+        reference_year,
+        day_of_year,
+        source,
+        dwd_phenology.species_name_de,
+        phase_name_de,
+        station_full
+    FROM
+        dwd_phenology, dwd_species_group
+    WHERE true
+        AND phase_name_en LIKE '%flowering%'
+        AND dwd_species_group.group_name = 'mellifera-de-primary'
+        AND dwd_phenology.species_id=dwd_species_group.species_id
+    ORDER BY reference_year, day_of_year;
+
+There is also a convenience view ``dwd_phenology_mellifera_de_primary``, which saves
+you from needing to join tables. Again, this statement lists all observations of
+"flowering" events for primary foraging plants of honeybees (apis mellifera), but
+also filters by location on behalf of the synthesized ``station_full`` field::
+
+    SELECT
+        reference_year,
+        day_of_year,
+        source,
+        species_name_de,
+        phase_name_de,
+        station_name
+    FROM dwd_phenology_mellifera_de_primary
+    WHERE true
+        AND phase_name_en LIKE '%flowering%'
+        AND station_full LIKE '%brandenburg%';
+
+In order to see what's inside, just query the ``dwd_species_group`` table like::
+
+    SELECT *
+    FROM dwd_species_group
+    WHERE group_name='mellifera-de-primary';
+
+::
+
+    species_id,group_name,species_name_de
+    113,mellifera-de-primary,Hasel
+    127,mellifera-de-primary,"Schneeglöckchen"
+    124,mellifera-de-primary,Sal-Weide
+    120,mellifera-de-primary,"Löwenzahn"
+    330,mellifera-de-primary,"Süßkirsche"
+    310,mellifera-de-primary,Apfel
+    205,mellifera-de-primary,Winterraps
+    121,mellifera-de-primary,Robinie
+    137,mellifera-de-primary,Winter-Linde
+    114,mellifera-de-primary,Heidekraut
 
 
 ************
@@ -290,6 +343,11 @@ Backlog
     - [o] Add a few SQL query examples
 
 
+----
+
+Enjoy your research.
+
+
 .. _copyright-de: https://www.dwd.de/DE/service/copyright/copyright_node.html
 .. _copyright-en: https://www.dwd.de/EN/service/copyright/copyright_node.html
 .. _data folder: https://phenodata.hiveeyes.org/data/
@@ -307,5 +365,6 @@ Backlog
 .. _PPODB: https://rumo.biologie.hu-berlin.de/PPODB/
 .. _PPODB SQL interface: https://rumo.biologie.hu-berlin.de/PPODB/database/sql_input
 .. _PPODB summary: https://community.hiveeyes.org/t/plant-phenological-online-database-ppodb/4888
+.. _presets.json: https://github.com/earthobservations/phenodata/blob/main/phenodata/dwd/presets.json
 .. _SQLite: https://sqlite.org/
 .. _The plant phenological online database (PPODB) » an online database for long-term phenological data: https://link.springer.com/article/10.1007/s00484-013-0650-2

--- a/phenodata/dwd/export.py
+++ b/phenodata/dwd/export.py
@@ -1,6 +1,8 @@
 import logging
 import typing as t
 
+import pandas as pd
+
 from phenodata.dwd.model import DwdPhenoDataset, DwdPhenoDatabase, DwdPhenoPartition
 from phenodata.dwd.pheno import DwdPhenoDataClient
 
@@ -12,10 +14,15 @@ def acquire_database(client: DwdPhenoDataClient, options: t.Optional[t.Dict[str,
     options = options or {}
     dataset = options.get("dataset", "unknown")
     partition = options.get("partition", "unknown")
+
+    species = client.get_species()
+    species_group = get_species_presets_df(species)
+
     db = DwdPhenoDatabase(
         dataset=DwdPhenoDataset(dataset),
         partition=DwdPhenoPartition(partition),
-        species=client.get_species(),
+        species=species,
+        species_group=species_group,
         phase=client.get_phases(),
         quality_level=client.get_quality_levels(),
         quality_byte=client.get_quality_bytes(),
@@ -37,3 +44,25 @@ def export_database(client, target, options):
     # Optionally print samples.
     # print(db.observations)
     logger.info(f"Exported data to {target}")
+
+
+def get_species_presets_df(species: pd.DataFrame):
+    """
+    Convert species groups from `presets.json` into DataFrame.
+    """
+    data = DwdPhenoDataClient.load_preset_species()
+    outdata = []
+    for group_name, items_raw in data.items():
+        items = list(map(str.strip, items_raw.split(",")))
+        for item in items:
+            result = species.query("Objekt == @item")
+            try:
+                species_id = result.index.values[0]
+            except:
+                logger.warning(f"Unable to discover species name in data: {item}")
+                continue
+            outitem = {"species_id": species_id, "group_name": group_name, "species_name_de": item}
+            outdata.append(outitem)
+    outdf = pd.DataFrame.from_records(outdata, index="species_id")
+    outdf.attrs["name"] = "species_group"
+    return outdf

--- a/phenodata/dwd/pheno.py
+++ b/phenodata/dwd/pheno.py
@@ -467,15 +467,24 @@ class DwdPhenoDataClient:
 
     @classmethod
     def load_preset(cls, section, option, name):
-        resource = pkg_resources.resource_stream(__name__, 'presets.json')
-        presets = json.load(resource)
+        presets = cls.load_preset_file()
         try:
             value = presets[section][option][name]
             return value
         except KeyError:
-            message = 'Preset "{}" not found in file "{}"'.format(name, resource.name)
+            message = f"Preset not found: {name}"
             logger.error(message)
             raise KeyError(message)
+
+    @classmethod
+    def load_preset_file(cls):
+        resource = pkg_resources.resource_stream(__name__, 'presets.json')
+        return json.load(resource)
+
+    @classmethod
+    def load_preset_species(cls):
+        return cls.load_preset_file()["options"]["species"]
+
 
 @attr.s
 class DwdPhenoDataHumanizer:


### PR DESCRIPTION
### Introduction
c100464a941 added a species/plant grouping feature based on the [`presets.json`](https://github.com/earthobservations/phenodata/blob/main/phenodata/dwd/presets.json) file. It is available, for example, by using the `--species-preset=mellifera-de-primary` command line option.

### Improvement
This patch unlocks that feature for the SQLite export subsystem added with GH-25. Now, it is easy to inquire the database for corresponding _**groups** of species/plants_, adding important functionality for [Phänologischer Kalender für Trachtpflanzen].

#### Example
```sql
    SELECT
        reference_year,
        day_of_year,
        source,
        species_name_de,
        phase_name_de,
        station_name
    FROM dwd_phenology_mellifera_de_primary
    WHERE true
        AND phase_name_en LIKE '%flowering%'
        AND station_full LIKE '%brandenburg%';
```

#### Documentation
https://phenodata.readthedocs.io/en/latest/archive/dwd.html#specialist-s-toolbox

[Phänologischer Kalender für Trachtpflanzen]: https://community.hiveeyes.org/t/phanologischer-kalender-fur-trachtpflanzen/664
